### PR TITLE
breaking: reimplement as a single function, without babel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
   - "node"
-  - "6.5"
+  - "12"
+  - "8"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## API
 
-### polyfill(file[, options])
+### secureRemove(file[, options])
 
 Securely remove a file, using a pure JS implementation.
 

--- a/package.json
+++ b/package.json
@@ -11,41 +11,31 @@
   "bugs": {
     "url": "https://github.com/ExodusMovement/secure-remove/issues"
   },
+  "engines": {
+    "node": ">=8"
+  },
   "license": "MIT",
   "author": "Kirill Fomichev <fanatid@ya.ru> (https://github.com/fanatid)",
   "files": [
-    "lib"
+    "src"
   ],
-  "main": "lib/index.js",
+  "main": "src/polyfill.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/ExodusMovement/secure-remove.git"
   },
   "scripts": {
-    "build": "babel src -d lib",
     "lint": "standard",
     "test": "npm run lint && npm run unit",
-    "posttest": "npm run build",
-    "unit": "tape -r babel-register test/index.js"
+    "unit": "tape test/index.js"
   },
   "dependencies": {
     "fs-extra": "^6.0.1"
   },
   "devDependencies": {
-    "babel-cli": "^6.14.0",
-    "babel-eslint": "^8.0.0",
-    "babel-plugin-transform-export-extensions": "^6.22.0",
-    "babel-preset-env": "^1.6.0",
-    "babel-register": "^6.14.0",
     "standard": "^10.0.3",
     "tape": "^4.6.0",
     "tape-promise": "^2.0.1",
     "tempfile": "^2.0.0"
-  },
-  "standard": {
-    "ignore": [
-      "lib"
-    ],
-    "parser": "babel-eslint"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "lint": "standard",
     "test": "npm run lint && npm run unit",
-    "unit": "tape test/index.js"
+    "unit": "tape test/testsuite.js"
   },
   "dependencies": {
     "fs-extra": "^6.0.1"

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,0 @@
-export polyfill from './polyfill'

--- a/src/polyfill.js
+++ b/src/polyfill.js
@@ -1,7 +1,7 @@
-import fs from 'fs-extra'
-import { randomBytes } from 'crypto'
+const fs = require('fs-extra')
+const { randomBytes } = require('crypto')
 
-export default async function polyfill (path, options = {}) {
+async function secureRemove (path, options = {}) {
   let fdTarget
   let fdSource
   const buffer = Buffer.alloc(16384)
@@ -83,3 +83,5 @@ export default async function polyfill (path, options = {}) {
     throw err
   }
 }
+
+module.exports = secureRemove

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,3 @@
-import testsuite from './testsuite'
+const testsuite = require('./testsuite')
 
-testsuite('polyfill')
+testsuite()

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,0 @@
-const testsuite = require('./testsuite')
-
-testsuite()

--- a/test/testsuite.js
+++ b/test/testsuite.js
@@ -4,48 +4,44 @@ const fs = require('fs-extra')
 const secureRemove = require('..')
 const tmp = require('tempfile')
 
-function testsuite () {
-  test(`file not exists`, async (t) => {
-    const tempfile = tmp()
+test(`file not exists`, async (t) => {
+  const tempfile = tmp()
 
-    await secureRemove(tempfile).catch((err) => {
-      t.true(err instanceof Error)
-      t.equal(err.message, `ENOENT: no such file or directory, stat '${tempfile}'`)
-    })
+  await secureRemove(tempfile).catch((err) => {
+    t.true(err instanceof Error)
+    t.equal(err.message, `ENOENT: no such file or directory, stat '${tempfile}'`)
   })
+})
 
-  test(`options.iterations is 1, as result data is not same`, async (t) => {
-    const tempfile = tmp()
-    let dataOriginal = randomBytes(1024)
-    await fs.writeFile(tempfile, dataOriginal)
-    await secureRemove(tempfile, { iterations: 1, randomSource: '/dev/urandom' })
-    const data = await fs.readFile(tempfile)
-    t.notEqual(dataOriginal.toString('hex'), data.toString('hex'))
-  })
+test(`options.iterations is 1, as result data is not same`, async (t) => {
+  const tempfile = tmp()
+  let dataOriginal = randomBytes(1024)
+  await fs.writeFile(tempfile, dataOriginal)
+  await secureRemove(tempfile, { iterations: 1, randomSource: '/dev/urandom' })
+  const data = await fs.readFile(tempfile)
+  t.notEqual(dataOriginal.toString('hex'), data.toString('hex'))
+})
 
-  test(`options.size = 42K`, async (t) => {
-    const tempfile = tmp()
-    await fs.writeFile(tempfile, randomBytes(42))
-    await secureRemove(tempfile, { size: '42K' })
-    const stat = await fs.stat(tempfile)
-    t.equal(stat.size, 42 * 1024)
-  })
+test(`options.size = 42K`, async (t) => {
+  const tempfile = tmp()
+  await fs.writeFile(tempfile, randomBytes(42))
+  await secureRemove(tempfile, { size: '42K' })
+  const stat = await fs.stat(tempfile)
+  t.equal(stat.size, 42 * 1024)
+})
 
-  test(`options.remove is true`, async (t) => {
-    const tempfile = tmp()
-    await fs.writeFile(tempfile, randomBytes(1024))
-    await secureRemove(tempfile, { remove: true })
-    const exists = await fs.pathExists(tempfile)
-    t.false(exists, 'file should not exist')
-  })
+test(`options.remove is true`, async (t) => {
+  const tempfile = tmp()
+  await fs.writeFile(tempfile, randomBytes(1024))
+  await secureRemove(tempfile, { remove: true })
+  const exists = await fs.pathExists(tempfile)
+  t.false(exists, 'file should not exist')
+})
 
-  test(`options.exact and options.zero is true`, async (t) => {
-    const tempfile = tmp()
-    await fs.writeFile(tempfile, randomBytes(1024))
-    await secureRemove(tempfile, { exact: true, zero: true })
-    const data = await fs.readFile(tempfile)
-    t.equal(data.toString('hex'), Buffer.alloc(1024).toString('hex'))
-  })
-}
-
-testsuite()
+test(`options.exact and options.zero is true`, async (t) => {
+  const tempfile = tmp()
+  await fs.writeFile(tempfile, randomBytes(1024))
+  await secureRemove(tempfile, { exact: true, zero: true })
+  const data = await fs.readFile(tempfile)
+  t.equal(data.toString('hex'), Buffer.alloc(1024).toString('hex'))
+})

--- a/test/testsuite.js
+++ b/test/testsuite.js
@@ -4,7 +4,7 @@ const fs = require('fs-extra')
 const secureRemove = require('..')
 const tmp = require('tempfile')
 
-module.exports = function () {
+function testsuite () {
   test(`file not exists`, async (t) => {
     const tempfile = tmp()
 
@@ -47,3 +47,5 @@ module.exports = function () {
     t.equal(data.toString('hex'), Buffer.alloc(1024).toString('hex'))
   })
 }
+
+testsuite()

--- a/test/testsuite.js
+++ b/test/testsuite.js
@@ -1,52 +1,48 @@
-import test from 'tape-promise/tape'
-import { randomBytes } from 'crypto'
-import fs from 'fs-extra'
-import * as secureRemove from '../src'
-import tmp from 'tempfile'
+const test = require('tape-promise/tape')
+const { randomBytes } = require('crypto')
+const fs = require('fs-extra')
+const secureRemove = require('..')
+const tmp = require('tempfile')
 
-export default function (method) {
-  test(`file not exists (${method})`, async (t) => {
+module.exports = function () {
+  test(`file not exists`, async (t) => {
     const tempfile = tmp()
-    const errors = {
-      polyfill: `ENOENT: no such file or directory, stat '${tempfile}'`,
-      shred: `Exit with 1, stderr:\nshred: ${tempfile}: failed to open for writing: No such file or directory\n`
-    }
 
-    await secureRemove[method](tempfile).catch((err) => {
+    await secureRemove(tempfile).catch((err) => {
       t.true(err instanceof Error)
-      t.equal(err.message, errors[method])
+      t.equal(err.message, `ENOENT: no such file or directory, stat '${tempfile}'`)
     })
   })
 
-  test(`options.iterations is 1, as result data is not same (${method})`, async (t) => {
+  test(`options.iterations is 1, as result data is not same`, async (t) => {
     const tempfile = tmp()
     let dataOriginal = randomBytes(1024)
     await fs.writeFile(tempfile, dataOriginal)
-    await secureRemove[method](tempfile, { iterations: 1, randomSource: '/dev/urandom' })
+    await secureRemove(tempfile, { iterations: 1, randomSource: '/dev/urandom' })
     const data = await fs.readFile(tempfile)
     t.notEqual(dataOriginal.toString('hex'), data.toString('hex'))
   })
 
-  test(`options.size = 42K (${method})`, async (t) => {
+  test(`options.size = 42K`, async (t) => {
     const tempfile = tmp()
     await fs.writeFile(tempfile, randomBytes(42))
-    await secureRemove[method](tempfile, { size: '42K' })
+    await secureRemove(tempfile, { size: '42K' })
     const stat = await fs.stat(tempfile)
     t.equal(stat.size, 42 * 1024)
   })
 
-  test(`options.remove is true (${method})`, async (t) => {
+  test(`options.remove is true`, async (t) => {
     const tempfile = tmp()
     await fs.writeFile(tempfile, randomBytes(1024))
-    await secureRemove[method](tempfile, { remove: true })
+    await secureRemove(tempfile, { remove: true })
     const exists = await fs.pathExists(tempfile)
     t.false(exists, 'file should not exist')
   })
 
-  test(`options.exact and options.zero is true (${method})`, async (t) => {
+  test(`options.exact and options.zero is true`, async (t) => {
     const tempfile = tmp()
     await fs.writeFile(tempfile, randomBytes(1024))
-    await secureRemove[method](tempfile, { exact: true, zero: true })
+    await secureRemove(tempfile, { exact: true, zero: true })
     const data = await fs.readFile(tempfile)
     t.equal(data.toString('hex'), Buffer.alloc(1024).toString('hex'))
   })


### PR DESCRIPTION
Depends on #2.

Single export (see https://github.com/ExodusMovement/secure-remove/pull/2#issuecomment-776041921), also remove outdated babel dependency.