### PR TITLE
refactor: remove fs-extra dep; use plain fs

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,6 @@
     "test": "npm run lint && npm run unit",
     "unit": "tape test/testsuite.js"
   },
-  "dependencies": {
-    "fs-extra": "^6.0.1"
-  },
   "devDependencies": {
     "standard": "^10.0.3",
     "tape": "^4.6.0",

--- a/src/polyfill.js
+++ b/src/polyfill.js
@@ -1,9 +1,9 @@
-const fs = require('fs-extra')
+const fs = require('fs/promises')
 const { randomBytes } = require('crypto')
 
 async function secureRemove (path, options = {}) {
-  let fdTarget
-  let fdSource
+  let targetFH
+  let sourceFH
   const buffer = Buffer.alloc(16384)
 
   try {
@@ -31,30 +31,30 @@ async function secureRemove (path, options = {}) {
     if (!(iterations >= 1)) throw new Error(`invalid iterations: ${options.iterations}`)
     if (options.zero) iterations -= 1
 
-    fdTarget = await fs.open(path, 'w')
+    targetFH = await fs.open(path, 'w')
     if (options.randomSource) {
-      fdSource = await fs.open(options.randomSource, 'r')
+      sourceFH = await fs.open(options.randomSource, 'r')
       let posSource = 0
       for (let i = 0, posTarget = 0; i < iterations; ++i) {
         while (posTarget < size) {
           const required = Math.min(buffer.length, size - posTarget)
-          const { bytesRead } = await fs.read(fdSource, buffer, 0, required, posSource)
+          const { bytesRead } = await sourceFH.read(buffer, 0, required, posSource)
           if (bytesRead === 0) throw new Error(`not enough data in ${options.randomSource}`)
           posSource += bytesRead
-          const { bytesWritten } = await fs.write(fdTarget, buffer, 0, bytesRead, posTarget)
+          const { bytesWritten } = await targetFH.write(buffer, 0, bytesRead, posTarget)
           if (bytesWritten !== bytesRead) throw new Error('lost data on overwrite')
           posTarget += bytesRead
         }
       }
 
-      await fs.close(fdSource)
-      fdSource = undefined
+      await sourceFH.close()
+      sourceFH = undefined
     } else {
       for (let i = 0; i < iterations; ++i) {
         for (let posTarget = 0; posTarget < size;) {
           const length = Math.min(16384, size - posTarget)
           const buffer = randomBytes(length)
-          const { bytesWritten } = await fs.write(fdTarget, buffer, 0, length, posTarget)
+          const { bytesWritten } = await targetFH.write(buffer, 0, length, posTarget)
           if (bytesWritten !== length) throw new Error('lost data on overwrite')
           posTarget += length
         }
@@ -65,21 +65,21 @@ async function secureRemove (path, options = {}) {
       buffer.fill(0)
       for (let posTarget = 0; posTarget < size;) {
         const length = Math.min(buffer.length, size - posTarget)
-        const { bytesWritten } = await fs.write(fdTarget, buffer, 0, length, posTarget)
+        const { bytesWritten } = await targetFH.write(buffer, 0, length, posTarget)
         if (bytesWritten !== length) throw new Error('lost data on overwrite')
         posTarget += length
       }
     }
 
-    await fs.close(fdTarget)
-    fdTarget = undefined
+    await targetFH.close()
+    targetFH = undefined
 
-    if (options.remove) await fs.remove(path)
+    if (options.remove) await fs.unlink(path)
   } catch (err) {
     await Promise.all(
-      [fdTarget, fdSource]
+      [targetFH, sourceFH]
         .filter(i => !!i)
-        .map(fd => fs.close(fd).catch(() => {}))
+        .map(fh => fh.close().catch(() => {}))
     ).catch(() => {}) // this last catch probably not needed, but never hurts
     throw err
   }

--- a/test/testsuite.js
+++ b/test/testsuite.js
@@ -1,6 +1,6 @@
 const test = require('tape-promise/tape')
 const { randomBytes } = require('crypto')
-const fs = require('fs-extra')
+const fs = require('fs/promises')
 const secureRemove = require('..')
 const tmp = require('tempfile')
 
@@ -34,8 +34,9 @@ test(`options.remove is true`, async (t) => {
   const tempfile = tmp()
   await fs.writeFile(tempfile, randomBytes(1024))
   await secureRemove(tempfile, { remove: true })
-  const exists = await fs.pathExists(tempfile)
-  t.false(exists, 'file should not exist')
+  const exists = await fs.stat(tempfile).catch(err => err)
+  t.equal(exists.constructor, Error, 'file should not exist')
+  t.equal(exists.code, 'ENOENT', 'file should not exist')
 })
 
 test(`options.exact and options.zero is true`, async (t) => {


### PR DESCRIPTION
This is an alternative to #5; we really don't even need graceful-fs here. Switched to using `fs/promises` API.

Closes #5 